### PR TITLE
chore: update actions to v4, Python 3.12, modernize cache

### DIFF
--- a/.github/workflows/releases.yaml
+++ b/.github/workflows/releases.yaml
@@ -5,40 +5,49 @@ on:
   schedule:
     - cron: "0 0 * * *" # every midnight GMT
 
+permissions:
+  contents: read
+
 jobs:
   releases:
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
-          python-version: "3.9"
+          python-version: '3.12'
+          cache: 'pip'
 
-      - name: Cache Python Packages
-        uses: actions/cache@v3
+      - name: Cache virtual environment
+        uses: actions/cache@v4
+        id: venv-cache
         with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+          path: ~/.venv
+          key: venv-${{ runner.os }}-${{ hashFiles('**/requirements.txt') }}-${{ hashFiles('.github/workflows/releases.yaml') }}
           restore-keys: |
-            ${{ runner.os }}-pip-
+            venv-${{ runner.os }}-${{ hashFiles('**/requirements.txt') }}-
+            venv-${{ runner.os }}-
 
-      - name: Install Dependencies
+      - name: Install dependencies
+        if: steps.venv-cache.outputs.cache-hit != 'true'
         run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements.txt || true
-        env:
-          PIP_CACHE_DIR: ~/.cache/pip
+          python -m venv ~/.venv
+          source ~/.venv/bin/activate
+          pip install --upgrade pip
+          pip install -r requirements.txt
 
       - name: Run Script
         env:
           HEADERS: ${{ secrets.HEADERS }}
           HASH: ${{ secrets.HASH }}
           AJAX: ${{ secrets.AJAX }}
-        run: python main.py
+        run: |
+          source ~/.venv/bin/activate
+          python main.py
 
       - name: Commit and Push Changes
         run: |-


### PR DESCRIPTION
Fixes the deprecation warning for Node.js 20 on GitHub Actions runners.

Changes:
- `actions/checkout@v3` → `actions/checkout@v4`
- `actions/setup-python@v4` → `actions/setup-python@v5`
- `actions/cache@v3` → `actions/cache@v4`
- Python `3.9` → `3.12` (3.9 is EOL)
- Modernized cache approach: venv-based caching instead of `~/.cache/pip`
- Added `permissions: contents: read` per GitHub security best practices